### PR TITLE
ci: add container publishing workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,22 @@
+name: Publish container
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_TOKEN }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Publish container to Docker Hub
+        run: docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6 --tag "mtoohey/standardnotes-extensions:$(git log -1 --format="%H" | cut -c -6)" --tag mtoohey/standardnotes-extensions:latest --push .

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ FROM python:3-alpine
 WORKDIR /build
 COPY requirements.txt build_repo.py ./
 
-RUN pip3 install -r requirements.txt
+RUN pip3 install --no-cache-dir -r requirements.txt
 
-ENTRYPOINT python3 build_repo.py
+ENTRYPOINT ["python3", "build_repo.py"]


### PR DESCRIPTION
Hello! I haven't done the best job of keeping the Docker Hub container up to date, and I figured it might be a good idea to set up CI so it happens automatically. This PR adds a GitHub action that will automatically build and push the container on multiple architectures each time the master branch is updated. The tags it uses are the first 6 characters of the commit's hash so people can pin versions if they'd like to, and the `latest` tag, if people want to stay up to date with that. The only thing that's a bit of an issue is how to inject the credentials. We can use GitHub secrets for that, but as far as I can tell, you can't scope tokens to a specific repo, and it's probably not good security for me to provide you with my access token, so if it's not too much work, would you be able to create an account and use your credentials? Let me know what you think would be best! If we end up going with that option, we just need to update the README to use your Docker Hub username.