### PR TITLE
ci: fix container publishing workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKER_HUB_TOKEN }}
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,4 +19,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Publish container to Docker Hub
-        run: docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6 --tag "mtoohey/standardnotes-extensions:$(git log -1 --format="%H" | cut -c -6)" --tag mtoohey/standardnotes-extensions:latest --push .
+        run: docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6 --tag "$DOCKER_HUB_USERNAME/standardnotes-extensions:$(git log -1 --format="%H" | cut -c -6)" --tag "$DOCKER_HUB_USERNAME/standardnotes-extensions:latest" --push .
+        env:
+          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}


### PR DESCRIPTION
Hi again, thanks for merging #27, sorry though, it looks like I made some mistakes, which this PR fixes. You'll also have to add your access token and username as secrets on the repo before it'll run successfully, I've [tested it properly](https://github.com/mtoohey31/standardnotes-extensions/runs/4337617895?check_suite_focus=true) now though, so it should work just fine. Lmk if you have any questions with how to set up the secrets.