### PR TITLE
Add info about self-hosted 'subscriptions'

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ https://your-domain.com/extensions/index.json
 ```
 * Import the `latest url` for each extension you want to add (for example: `https://your-domaim.com/extensions/bold-editor/index.json`) into the Standard Notes Web Desktop client under the `General` > `Advanced Settings` > `Install Custom Extension` menu. (Note: Enable CORS for your web server respectively, nginx setup provided below)
 
-* If you are self-hosting Standard Notes Server (aka [Standard Notes Standalone](https://github.com/standardnotes/standalone), you may need to add a "subscription" to your self-hosted user account in order to avoid any problems accessing official Standard Notes extensions. 
+* If you are self-hosting Standard Notes Server (aka [Standard Notes Standalone](https://github.com/standardnotes/standalone)), you may need to add a "subscription" to your self-hosted user account in order to avoid any problems accessing official Standard Notes extensions. 
 * To add a subscription to your self-hosted user account, run the following commands (Replace EMAIL@ADDR with your user email) from within your standalone directory:
 `./server.sh create-subscription EMAIL@ADDR`
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ https://your-domain.com/extensions/index.json
 ```
 * Import the `latest url` for each extension you want to add (for example: `https://your-domaim.com/extensions/bold-editor/index.json`) into the Standard Notes Web Desktop client under the `General` > `Advanced Settings` > `Install Custom Extension` menu. (Note: Enable CORS for your web server respectively, nginx setup provided below)
 
+* If you are self-hosting Standard Notes Server (aka [Standard Notes Standalone](https://github.com/standardnotes/standalone), you may need to add a "subscription" to your self-hosted user account in order to avoid any problems accessing official Standard Notes extensions. 
+* To add a subscription to your self-hosted user account, run the following commands (Replace EMAIL@ADDR with your user email) from within your standalone directory:
+`./server.sh create-subscription EMAIL@ADDR`
+
 ### Docker
 
 * To run via Docker, clone this repository, create your `.env` file using the provided `env.sample`, and optionally add any additional extensions to the `/extensions` directory, following the instructions above.

--- a/extensions/advanced-checklist.yaml
+++ b/extensions/advanced-checklist.yaml
@@ -7,7 +7,7 @@ main: public/index.html
 name: Advanced Checklist
 content_type: SN|Component
 area: editor-editor
-version: 0.0.1
+version: 0.0.2
 marketing_url: https://github.com/standardnotes/advanced-checklist
 thumbnail_url:
 description: A task editor with grouping functionality.

--- a/extensions/advanced-checklist.yaml
+++ b/extensions/advanced-checklist.yaml
@@ -1,7 +1,7 @@
 ---
 id: org.standardnotes.advanced-checklist
 npm: sn-advanced-checklist
-github: standardnotes/advanced-checklist
+github: xthursdayx/advanced-checklist
 main: public/index.html
 
 name: Advanced Checklist

--- a/extensions/advanced-checklist.yaml
+++ b/extensions/advanced-checklist.yaml
@@ -1,0 +1,15 @@
+---
+id: org.standardnotes.advanced-checklist
+npm: sn-advanced-checklist
+github: standardnotes/advanced-checklist
+main: dist/index.html
+
+name: Simple Markdown Editor
+content_type: SN|Component
+area: editor-editor
+version: 0.1.0
+marketing_url: https://github.com/standardnotes/advanced-checklist
+thumbnail_url:
+description: A task editor with grouping functionality.
+flags: []
+...

--- a/extensions/advanced-checklist.yaml
+++ b/extensions/advanced-checklist.yaml
@@ -4,7 +4,7 @@ npm: sn-advanced-checklist
 github: standardnotes/advanced-checklist
 main: dist/index.html
 
-name: Simple Markdown Editor
+name: Advanced Checklist
 content_type: SN|Component
 area: editor-editor
 version: 0.1.0

--- a/extensions/advanced-checklist.yaml
+++ b/extensions/advanced-checklist.yaml
@@ -2,7 +2,7 @@
 id: org.standardnotes.advanced-checklist
 npm: sn-advanced-checklist
 github: standardnotes/advanced-checklist
-main: dist/index.html
+main: public/index.html
 
 name: Advanced Checklist
 content_type: SN|Component

--- a/extensions/advanced-checklist.yaml
+++ b/extensions/advanced-checklist.yaml
@@ -7,7 +7,7 @@ main: public/index.html
 name: Advanced Checklist
 content_type: SN|Component
 area: editor-editor
-version: 0.1.0
+version: 0.0.1
 marketing_url: https://github.com/standardnotes/advanced-checklist
 thumbnail_url:
 description: A task editor with grouping functionality.

--- a/extensions/markdown-visual.yaml
+++ b/extensions/markdown-visual.yaml
@@ -1,0 +1,15 @@
+---
+id: org.standardnotes.markdown-visual
+npm: sn-markdown-visual
+github: standardnotes/markdown-visual
+main: public/index.html
+
+name: Markdown Visual Editor
+content_type: SN|Component
+area: editor-editor
+version: 1.0.0
+marketing_url: https://standardnotes.org/extensions/markdown-visual
+thumbnail_url:
+description: A lightweight WYSIWYG markdown editor, derivated from Milkdown editor.
+flags: []
+...

--- a/standardnotes-extensions-list.txt
+++ b/standardnotes-extensions-list.txt
@@ -2,6 +2,7 @@
 # List of standard notes's extensions who's identifier need to be modified to
 # get around the issue: https://github.com/standardnotes/desktop/issues/789
 #############################################################################
+advanced-checklist.yaml
 action-bar.yaml
 autobiography-theme.yaml
 autocomplete-tags.yaml
@@ -14,6 +15,7 @@ futura-theme.yaml
 github-push.yaml
 markdown-basic.yaml
 markdown-pro-editor.yaml
+markdown-visual.yaml
 math-editor.yaml
 mfa-link.yaml
 midnight-theme.yaml


### PR DESCRIPTION
Some people have had problems accessing self-hosted versions of the official Standard Notes extensions when they are also self-hosting Standard Notes Server Infrastructure.  I have added information to the README about creating a "subscription" to your self-hosted accounts to avoid this issue. 

See:
https://github.com/standardnotes/standalone/issues/64#issuecomment-1064719310
&
https://github.com/iganeshk/standardnotes-extensions/issues/41